### PR TITLE
Implement `snap()` for single frame capture

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -9,6 +9,7 @@ __license__ = "MIT"
 
 import sys
 import contextlib
+import re
 
 
 def capture(camera=None,
@@ -143,7 +144,13 @@ def snap(*args, **kwargs):
     kwargs['format'] = format
     kwargs['viewer'] = viewer
 
-    return capture(*args, **kwargs)
+    output = capture(*args, **kwargs)
+
+    # substitute any # in the output to the actual frame number
+    replace = lambda m: str(frame).zfill(len(m.group()))
+    output = re.sub("#+", replace, output)
+
+    return output
 
 
 class ViewportOptions:

--- a/capture.py
+++ b/capture.py
@@ -138,8 +138,10 @@ def snap(*args, **kwargs):
     # override capture defaults
     format = kwargs.pop('format', "image")
     compression = kwargs.pop('compression', "png")
+    viewer = kwargs.pop('viewer', False)
     kwargs['compression'] = compression
     kwargs['format'] = format
+    kwargs['viewer'] = viewer
 
     return capture(*args, **kwargs)
 

--- a/capture.py
+++ b/capture.py
@@ -41,9 +41,9 @@ def capture(camera=None,
             none is specified, no files are saved.
         start_frame (float, optional): Defaults to current start frame.
         end_frame (float, optional): Defaults to current end frame.
-        frame (float or tuple, optional): A single frame, tuple of frames or
-            frame ranges. This can be used to capture a single frame or an
-            arbitrary sequence of frames.
+        frame (float or tuple, optional): A single frame or list of frames.
+            Use this to capture a single frame or an arbitrary sequence of
+            frames.
         format (str, optional): Name of format, defaults to "qt".
         compression (str, optional): Name of compression, defaults to "h264"
         off_screen (bool, optional): Whether or not to playblast off screen
@@ -88,14 +88,6 @@ def capture(camera=None,
     height = height or cmds.getAttr("defaultResolution.height")
     start_frame = start_frame or cmds.playbackOptions(minTime=True, query=True)
     end_frame = end_frame or cmds.playbackOptions(maxTime=True, query=True)
-
-    # Ensure frame sequences is flattened list if list is provided
-    if frame is not None:
-        if isinstance(frame, (list, tuple)):
-            iterable = ([x] if isinstance(x, (float, int)) else x
-                        for x in frame)
-            frame = list(itertools.chain.from_iterable(iterable))
-            print frame
 
     # We need to wrap `completeFilename`, otherwise even when None is provided
     # it will use filename as the exact name. Only when lacking as argument

--- a/capture.py
+++ b/capture.py
@@ -72,14 +72,6 @@ def capture(camera=None,
 
     from maya import cmds
 
-    playblast_kwargs = dict()
-    if complete_filename is not None:
-        playblast_kwargs['completeFilename'] = complete_filename
-        playblast_kwargs['filename'] = filename
-    else:
-        playblast_kwargs['filename'] = filename
-
-
     camera = camera or "persp"
     width = width or cmds.getAttr("defaultResolution.width")
     height = height or cmds.getAttr("defaultResolution.height")
@@ -109,7 +101,8 @@ def capture(camera=None,
                         endTime=end_frame,
                         offScreen=off_screen,
                         forceOverwrite=overwrite,
-                        **playblast_kwargs)
+                        filename=filename,
+                        completeFilename=complete_filename)
 
         return output
 

--- a/capture.py
+++ b/capture.py
@@ -78,6 +78,13 @@ def capture(camera=None,
     start_frame = start_frame or cmds.playbackOptions(minTime=True, query=True)
     end_frame = end_frame or cmds.playbackOptions(maxTime=True, query=True)
 
+    # We need to wrap `completeFilename`, otherwise even when None is provided
+    # it will use filename as the exact name. Only when lacking as argument
+    # does it function correctly.
+    playblast_kwargs = dict()
+    if complete_filename:
+        playblast_kwargs['completeFilename'] = complete_filename
+
     with _independent_panel(
             width=width,
             height=height,
@@ -102,7 +109,7 @@ def capture(camera=None,
                         offScreen=off_screen,
                         forceOverwrite=overwrite,
                         filename=filename,
-                        completeFilename=complete_filename)
+                        **playblast_kwargs)
 
         return output
 
@@ -128,18 +135,13 @@ def snap(*args, **kwargs):
     kwargs['start_frame'] = frame
     kwargs['end_frame'] = frame
 
-    # ensure we use `complete_filename` parameter so we save under exact name
-    # instead of having the frame number padded into it.
-    kwargs['complete_filename'] = kwargs.pop('complete_filename',
-                                             kwargs.pop('filename', None))
-
     # override capture defaults
     format = kwargs.pop('format', "image")
     compression = kwargs.pop('compression', "png")
     kwargs['compression'] = compression
     kwargs['format'] = format
 
-    capture(*args, **kwargs)
+    return capture(*args, **kwargs)
 
 
 class ViewportOptions:


### PR DESCRIPTION
Implementation of `snap()` method for single frame capture. It defaults to format `image` and compression `png`. To keep functionality in sync with `capture()` it uses a direct call to capture.

#### Example

```python
import capture

# simple and quick
capture.snap()

# with viewport options saving an image of a specified frame with padding
view_opts = capture.ViewportOptions()
view_opts.nurbsCurves = True
view_opts.nurbsSurfaces = True
capture.snap(filename='D:/test_with_padding.png', 
             overwrite=True, 
             viewport_options=view_opts, 
             frame=5)

# with viewport options saving an image of a specified frame without padding (exact filename)
view_opts = capture.ViewportOptions()
view_opts.nurbsCurves = True
view_opts.nurbsSurfaces = True
capture.snap(complete_filename='D:/test_no_padding.png', 
             overwrite=True, 
             viewport_options=view_opts, 
             frame=5)
``