### PR TITLE
Fix resolution mismatch (#17) and center panel on screen for best view…

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -202,6 +202,8 @@ class ViewportOptions:
     useDefaultMaterial = False
     wireframeOnShaded = False
     displayAppearance = 'smoothShaded'
+    selectionHiliteDisplay = False
+    headsUpDisplay = True
 
     # Visibility flags
     nurbsCurves = False


### PR DESCRIPTION
…ing.

- Moved `maintain_aspect_ratio` to `capture()` command so it could also be used for `maya.cmds.playblast` widthHeight.
- Center the independent on the screen to improve the viewing experience.