### PR TITLE
Parse (active) view

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -259,6 +259,45 @@ DisplayOptions = {
     "backgroundBottom": (0.052, 0.052, 0.052),
 }
 
+# These display options require a different command to be queried and set
+_DisplayOptionsRGB = set(["background", "backgroundTop", "backgroundBottom"])
+        
+        
+def parse_active_view():
+    """Parse the current settings from the active view"""
+    
+    panel = cmds.getPanel(wf=True)
+    camera = cmds.modelEditor(panel, q=1, camera=1)
+    return parse_view(panel, camera)
+
+        
+def parse_view(panel, camera):
+    """Parse the scene, panel and camera for their current settings"""
+
+    # Display options
+    display_options = {}
+    for key in DisplayOptions.keys():
+        if key in _DisplayOptionsRGB:
+            display_options[key] = cmds.displayRGBColor(key, query=True)
+        else:
+            display_options[key] = cmds.displayPref(query=True, **{key: True})
+            
+    # Viewport options
+    viewport_options = {}
+    for key in ViewportOptions.keys():
+        viewport_options[key] = cmds.modelEditor(panel, query=True, **{key: True})
+
+    # Camera options
+    camera_options = {}
+    for key in CameraOptions.keys():
+        camera_options[key] = cmds.getAttr("{0}.{1}".format(camera, key))
+    
+    return {
+        "viewport_options": viewport_options,
+        "display_options": display_options,
+        "camera_options": camera_options
+    }
+
 
 @contextlib.contextmanager
 def _independent_panel(width, height):

--- a/capture.py
+++ b/capture.py
@@ -267,6 +267,12 @@ def parse_active_view():
     """Parse the current settings from the active view"""
     
     panel = cmds.getPanel(wf=True)
+    
+    # This happens when last focus was on panel
+    # that got deleted (e.g. `capture()` then `parse_active_view()`)
+    if not panel:
+        raise RuntimeError("No active panel")
+
     camera = cmds.modelEditor(panel, q=1, camera=1)
     return parse_view(panel, camera)
 

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,26 @@ def test_viewport_options():
     capture.capture(viewport_options={"wireframeOnShaded": True})
 
 
+def test_parse_active_view():
+    """Parse active view works"""
+
+    # Set focus to modelPanel1 (assume it exists)
+    # Otherwise the panel with focus (temporary panel from capture)
+    # got deleted and there's no "active panel"
+    import maya.cmds as cmds
+    cmds.setFocus("modelPanel1")
+
+    options = capture.parse_active_view()
+    capture.capture(**options)
+
+
+def test_parse_view():
+    """Parse view works"""
+
+    options = capture.parse_view("modelPanel1", "front")
+    capture.capture(**options)
+
+
 def test_preset():
     preset = {
         "width": 320,


### PR DESCRIPTION
Parse the active view so they can also be used as options.

```python
import capture

options = capture.parse_active_view()
capture.capture(**options)
```

Technical artists can also specify a specific camera and panel using `capture.parse_view(panel, camera)`.