### PR TITLE
Implement `apply_view` and `applied_view`

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -324,13 +324,11 @@ Viewport2Options = {
 
 def apply_view(panel, 
                           camera, 
-                          display_options,
-                          camera_options,
-                          viewport_options,
-                          viewport2_options):
+                          **options):
     """Apply options to the camera and panel"""
 
     # Display options
+    display_options = options.get("display_options", {})
     for key, value in display_options.iteritems():
         if key in _DisplayOptionsRGB:
             cmds.displayRGBColor(key, *value)
@@ -338,13 +336,16 @@ def apply_view(panel,
             cmds.displayPref(**{key: value})
 
     # Camera options
+    camera_options = options.get("camera_options", {})
     for key, value in camera_options.iteritems():
         cmds.setAttr("{0}.{1}".format(camera, key), value)
             
     # Viewport options
+    viewport_options = options.get("viewport_options", {})
     for key, value in viewport_options.iteritems():
         cmds.modelEditor(panel, edit=True, **{key: value})
 
+    viewport2_options = options.get("viewport2_options", {})
     for key, value in viewport2_options.iteritems():
         attr = "hardwareRenderingGlobals.{0}".format(key)
         cmds.setAttr(attr, value)

--- a/capture.py
+++ b/capture.py
@@ -320,6 +320,48 @@ Viewport2Options = {
     "useMaximumHardwareLights": True,
     "vertexAnimationCache": 0
  }
+ 
+
+def apply_view(panel, 
+                          camera, 
+                          display_options,
+                          camera_options,
+                          viewport_options,
+                          viewport2_options):
+    """Apply options to the camera and panel"""
+
+    # Display options
+    for key, value in display_options.iteritems():
+        if key in _DisplayOptionsRGB:
+            cmds.displayRGBColor(key, *value)
+        else:
+            cmds.displayPref(**{key: value})
+
+    # Camera options
+    for key, value in camera_options.iteritems():
+        cmds.setAttr("{0}.{1}".format(camera, key), value)
+            
+    # Viewport options
+    for key, value in viewport_options.iteritems():
+        cmds.modelEditor(panel, edit=True, **{key: value})
+
+    for key, value in viewport2_options.iteritems():
+        attr = "hardwareRenderingGlobals.{0}".format(key)
+        cmds.setAttr(attr, value)
+        
+
+@contextlib.contextmanager
+def applied_view(panel, 
+                             camera, 
+                             **options):
+    """Apply options to panel and camera during the context"""
+    
+    original = parse_view(panel, camera)
+    apply_view(panel, camera, **options)
+    try:
+        yield
+    finally:
+        apply_view(panel, camera, **original)
 
         
 def parse_active_view():

--- a/tests.py
+++ b/tests.py
@@ -90,6 +90,175 @@ def test_apply_parsed_view_exact():
     capture.apply_view(panel, camera, viewport_options={"displayAppearance": "wireframe"})
     assert cmds.modelEditor(panel, query=True, displayAppearance=True) == "wireframe"
 
+
+def test_apply_parsed_view_all():
+    """Apply parsed view all options works"""
+
+    # A set of options all trying to be different from the default
+    # settings (in `capture.py`) so we can test "changing states"
+    camera_options = {
+        "displayGateMask": True,
+        "displayResolution": True,
+        "displayFilmGate": True,
+        "displayFieldChart": True,
+        "displaySafeAction": True,
+        "displaySafeTitle": True,
+        "displayFilmPivot": True,
+        "displayFilmOrigin": True,
+        "overscan": 2.0,
+        "depthOfField": True,
+    }
+
+    display_options = {
+        "displayGradient": False,
+        "background": (0.0, 1, 0.1),
+        "backgroundTop": (0.6, 0.1, 0.1),
+        "backgroundBottom": (0.1, 0.1, 0.1),
+    }
+
+    viewport_options = {
+        "rendererName": "vp2Renderer",
+        "fogging": True,
+        "fogMode": "linear",
+        "fogDensity": 0.2,
+        "fogStart": 0,
+        "fogEnd": 5,
+        "fogColor": (0.3, 1, 2, 3),
+        "shadows": True,
+        "depthOfFieldPreview": True,
+        "displayTextures": False,
+        "displayLights": "default",
+        "useDefaultMaterial": True,
+        "wireframeOnShaded": True,
+        "displayAppearance": 'smoothShaded',
+        "selectionHiliteDisplay": True,
+        "headsUpDisplay": False,
+        "nurbsCurves": True,
+        "nurbsSurfaces": True,
+        "polymeshes": False,
+        "subdivSurfaces": True,
+        "cameras": True,
+        "lights": True,
+        "grid": True,
+        "joints": True,
+        "ikHandles": True,
+        "deformers": True,
+        "dynamics": True,
+        "fluids": True,
+        "hairSystems": True,
+        "follicles": True,
+        "nCloths": True,
+        "nParticles": True,
+        "nRigids": True,
+        "dynamicConstraints": True,
+        "locators": True,
+        "manipulators": True,
+        "dimensions": True,
+        "handles": True,
+        "pivots": True,
+        "textures": True,
+        "strokes": True
+    }
+
+    viewport2_options = {
+        "consolidateWorld": False,
+        "enableTextureMaxRes": True,
+        "bumpBakeResolution": 32,
+        "colorBakeResolution": 32,
+        "floatingPointRTEnable": False,
+        "floatingPointRTFormat": 2,
+        "gammaCorrectionEnable": True,
+        "gammaValue": 1.0,
+        "holdOutDetailMode": 2,
+        "holdOutMode": False,
+        "hwFogEnable": True,
+        "hwFogColorR": 0.4,
+        "hwFogColorG": 0.3,
+        "hwFogColorB": 0.2,
+        "hwFogAlpha": 0.4,
+        "hwFogDensity": 0.4,
+        "hwFogEnd": 200.0,
+        "hwFogFalloff": 1,
+        "hwFogStart": 10.0,
+        "lineAAEnable": True,
+        "maxHardwareLights": 4,
+        "motionBlurEnable": True,
+        "motionBlurSampleCount": 4,
+        "motionBlurShutterOpenFraction": 0.4,
+        "motionBlurType": 0,
+        "multiSampleCount": 4,
+        "multiSampleEnable": True,
+        "singleSidedLighting": True,
+        "ssaoEnable": True,
+        "ssaoAmount": 0.5,
+        "ssaoFilterRadius": 8,
+        "ssaoRadius": 8,
+        "ssaoSamples": 8,
+        "textureMaxResolution": 1024,
+        "threadDGEvaluation": True,
+        "transparencyAlgorithm": 1,
+        "transparencyQuality": 0.55,
+        "useMaximumHardwareLights": False,
+        "vertexAnimationCache": 0
+     }
+
+    defaults = {
+        "camera_options": capture.CameraOptions.copy(),
+        "display_options": capture.DisplayOptions.copy(),
+        "viewport_options": capture.ViewportOptions.copy(),
+        "viewport2_options": capture.Viewport2Options.copy(),
+    }
+
+    others = {
+        "camera_options": camera_options,
+        "display_options": display_options,
+        "viewport_options": viewport_options,
+        "viewport2_options": viewport2_options,
+    }
+
+    panel = "modelPanel1"
+    camera = "persp"
+
+    def compare(this, other):
+        """Compare options for only settings available in `this`
+
+        Some color values will be returned with possible floating
+        point precision errors as such result in a slightly
+        different number. We'd need to compare whilst keeping
+        such imprecisions in mind.
+        """
+        precision = 1e-4
+
+        for opt in this:
+            this_option = this[opt]
+            other_option = other[opt]
+
+            for key, value in this_option.iteritems():
+                other_value = other_option[key]
+
+                if isinstance(value, float) or isinstance(other_value, float):
+                    if abs(value - other_value) > precision:
+                        return False
+                elif isinstance(value, (tuple, list)):
+                    # Assuming for now that any tuple or list contains floats
+                    if not all((abs(a-b) < precision) for a, b in zip(value, other_value)):
+                        return False
+                else:
+                   if value != other_value:
+                    return False
+        
+        return True
+    
+    # Apply defaults and check
+    capture.apply_view(panel, camera, **defaults)
+    parsed_defaults = capture.parse_view(panel, camera)
+    assert compare(defaults, parsed_defaults)
+    
+    # Apply others and check
+    capture.apply_view(panel, camera, **others)
+    parsed_others = capture.parse_view(panel, camera)
+    assert compare(others, parsed_others)
+
     
 def test_preset():
     preset = {

--- a/tests.py
+++ b/tests.py
@@ -91,7 +91,6 @@ def test_apply_parsed_view_exact():
     assert cmds.modelEditor(panel, query=True, displayAppearance=True) == "wireframe"
 
     
-
 def test_preset():
     preset = {
         "width": 320,

--- a/tests.py
+++ b/tests.py
@@ -54,7 +54,18 @@ def test_parse_view():
 
     options = capture.parse_view("modelPanel1", "front")
     capture.capture(**options)
+    
+    
+def test_apply_view():
+    """Apply view works"""
+    capture.apply_view("modelPanel1", "persp", camera_options={"overscan": 2})
 
+    
+def test_apply_parsed_view():
+    """Apply parsed view works"""
+    options = capture.parse_view("modelPanel1", "persp")
+    capture.apply_view("modelPanel1", "persp", **options)
+    
 
 def test_preset():
     preset = {

--- a/tests.py
+++ b/tests.py
@@ -65,6 +65,31 @@ def test_apply_parsed_view():
     """Apply parsed view works"""
     options = capture.parse_view("modelPanel1", "persp")
     capture.apply_view("modelPanel1", "persp", **options)
+
+
+def test_apply_parsed_view_exact():
+    """Apply parsed view sanity check works"""
+    
+    import maya.cmds as cmds
+    panel = "modelPanel1"
+    camera = "persp"
+
+    cmds.modelEditor(panel, edit=True, displayAppearance="wireframe")
+    parsed = capture.parse_view(panel, camera)
+    display = parsed["viewport_options"]["displayAppearance"]
+    assert display == "wireframe"
+
+    # important to test both, just in case wireframe was already
+    # set when making the first query, and to make sure this
+    # actually does something.
+    cmds.modelEditor(panel, edit=True, displayAppearance="smoothShaded")
+    parsed = capture.parse_view(panel, camera)
+    display = parsed["viewport_options"]["displayAppearance"]
+    assert display == "smoothShaded"
+
+    capture.apply_view(panel, camera, viewport_options={"displayAppearance": "wireframe"})
+    assert cmds.modelEditor(panel, query=True, displayAppearance=True) == "wireframe"
+
     
 
 def test_preset():


### PR DESCRIPTION
Implement the function and context manager to easily apply parsed options with the `parse_view` command.

```python
import capture

# Parsing options
options = capture.parse_view("modelPanel1", "top")

# Applying options
capture.apply_view("modelPanel1", "persp", **options)

# Context manager
with capture.applied_view("modelPanel1", "persp", **options):
    pass
```

This only adds the function and does not yet swap it out in the `capture()` method as a replacement to the separate `_applied_*_options*` functions.